### PR TITLE
fix: update fg color for all languages

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -144,27 +144,27 @@ format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 [php]
 symbol = ""
 style = "bg:teal"
-format = '[[ $symbol( $version) ](fg:color_fg0 bg:teal)]($style)'
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 
 [java]
 symbol = " "
 style = "bg:teal"
-format = '[[ $symbol( $version) ](fg:color_fg0 bg:teal)]($style)'
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 
 [kotlin]
 symbol = ""
 style = "bg:teal"
-format = '[[ $symbol( $version) ](fg:color_fg0 bg:teal)]($style)'
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 
 [haskell]
 symbol = ""
 style = "bg:teal"
-format = '[[ $symbol( $version) ](fg:color_fg0 bg:teal)]($style)'
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 
 [python]
 symbol = ""
 style = "bg:teal"
-format = '[[ $symbol( $version) ](fg:color_fg0 bg:teal)]($style)'
+format = '[[ $symbol( $version) ](fg:base bg:teal)]($style)'
 
 [docker_context]
 symbol = ""


### PR DESCRIPTION
Thanks for the "catppuccin rainbow" starship preset!

This PR update specs for php, python and few other languages to have foreground color from the cattppuccin palette (rather than the original gruvbox_dark palette) 
