### PR TITLE
fix(hyprland): update config to match latest Hyprland and Hyprpaper syntax

### DIFF
--- a/hyprland/.config/hypr/hyprland.conf
+++ b/hyprland/.config/hypr/hyprland.conf
@@ -89,10 +89,12 @@ decoration {
         passes = 1
     }
 
-    drop_shadow = yes
-    shadow_range = 4
-    shadow_render_power = 3
-    col.shadow = rgba(1a1a1aee)
+    shadow {
+        enabled = yes
+        range = 4
+        render_power = 3
+        color = rgba(1a1a1aee)
+    }
 }
 
 animations {
@@ -140,7 +142,10 @@ device {
 # windowrulev2 = float,class:^(kitty)$,title:^(kitty)$
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 windowrulev2 = suppressevent maximize, class:.* # You'll probably like this.
-layerrule = noanim, wofi
+layerrule {
+    name = wofi
+    no_anim = yes
+}
 
 # See https://wiki.hyprland.org/Configuring/Keywords/ for more
 $mainMod = super

--- a/hyprpaper/.config/hypr/hyprpaper.conf
+++ b/hyprpaper/.config/hypr/hyprpaper.conf
@@ -1,2 +1,4 @@
-preload = ~/.config/backgrounds/shaded.png
-wallpaper = , ~/.config/backgrounds/shaded.png
+wallpaper {
+  monitor =
+  path = ~/.config/backgrounds/shaded.png
+}


### PR DESCRIPTION
- Replace deprecated shadow options with new `shadow {}` block
- Update `layerrule` syntax to structured block format
- Migrate hyprpaper wallpaper config to new block-based syntax
- Fix startup errors caused by removed or renamed config keys